### PR TITLE
Add hyperlink to github-ribbon

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -58,6 +58,9 @@ class App extends Component {
     this.setState({ lists})
     socket.emit('newLists', { lists})
   }
+  forkMe () {
+    window.open("https://github.com/bossbossk20/youtube-player-socket.io");
+  }
   render () {
     const { lists, showPlaylist, searchs } = this.state
     const opts = {
@@ -68,10 +71,6 @@ class App extends Component {
       }
     }
     return (
-      <div>
-      <div style={{position: 'absolute', top: '0', left: '0', border: '0' }}>
-      <img src="https://camo.githubusercontent.com/121cd7cbdc3e4855075ea8b558508b91ac463ac2/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f677265656e5f3030373230302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_green_007200.png"/>
-      </div>
       <div style={{marginTop: '30px', marginRight: '10px'}}>
         <Row>
           <Col md={16} xs={24} style={{textAlign: 'center'}}>
@@ -110,8 +109,8 @@ class App extends Component {
           </div>
           </Col>
         </Row>
+        <img src="https://camo.githubusercontent.com/121cd7cbdc3e4855075ea8b558508b91ac463ac2/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f677265656e5f3030373230302e706e67" alt="Fork me on Github" onClick={this.forkMe} style={{position: 'absolute', top: '0', left: '0', border: '0', cursor:'pointer'}}/>
       </div>
-    </div>
     )
   }
 }


### PR DESCRIPTION
Added a onClick handler `forkMe()` to the github ribbon that opens the
github repository in a new tab/window.

Also re-ordered the github-ribbon image element at the end.
This ensures the img element is rendered on top of other elements on
the page thus avoiding a click "dead-zone" on the github-ribbon.
![image](https://user-images.githubusercontent.com/1897177/31056379-540dd2d4-a6ee-11e7-80d9-a0f82a80cb88.png)
