### PR TITLE
#57 Refactor code: Move registration lambda into own function to make the code a bit more readable

### DIFF
--- a/src/registerServiceWorker.js
+++ b/src/registerServiceWorker.js
@@ -8,44 +8,46 @@
 // To learn more about the benefits of this model, read https://goo.gl/KwvDNy.
 // This link also includes instructions on opting out of this behavior.
 
+function setupRegistrationEvents(registration) {
+  registration.onupdatefound = () => {
+    const installingWorker = registration.installing
+    installingWorker.onstatechange = () => {
+      if (installingWorker.state === 'installed') {
+        if (navigator.serviceWorker.controller) {
+          // At this point, the old content will have been purged and
+          // the fresh content will have been added to the cache.
+          // It's the perfect time to display a "New content is
+          // available; please refresh." message in your web app.
+          console.log('New content is available; please refresh.')
+        } else {
+          // At this point, everything has been precached.
+          // It's the perfect time to display a
+          // "Content is cached for offline use." message.
+          console.log('Content is cached for offline use.')
+        }
+      }
+    }
+  }
+}
+
 export default function register() {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     window.addEventListener('load', () => {
-      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`
       navigator.serviceWorker
         .register(swUrl)
-        .then(registration => {
-          registration.onupdatefound = () => {
-            const installingWorker = registration.installing;
-            installingWorker.onstatechange = () => {
-              if (installingWorker.state === 'installed') {
-                if (navigator.serviceWorker.controller) {
-                  // At this point, the old content will have been purged and
-                  // the fresh content will have been added to the cache.
-                  // It's the perfect time to display a "New content is
-                  // available; please refresh." message in your web app.
-                  console.log('New content is available; please refresh.');
-                } else {
-                  // At this point, everything has been precached.
-                  // It's the perfect time to display a
-                  // "Content is cached for offline use." message.
-                  console.log('Content is cached for offline use.');
-                }
-              }
-            };
-          };
-        })
+        .then(setupRegistrationEvents)
         .catch(error => {
-          console.error('Error during service worker registration:', error);
-        });
-    });
+          console.error('Error during service worker registration:', error)
+        })
+    })
   }
 }
 
 export function unregister() {
   if ('serviceWorker' in navigator) {
     navigator.serviceWorker.ready.then(registration => {
-      registration.unregister();
-    });
+      registration.unregister()
+    })
   }
 }


### PR DESCRIPTION
I moved the lambda used to setup the registration event handlers to an own method so that the code has not so much nesting.